### PR TITLE
Small adjustments to config and error handling

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,3 +1,6 @@
+# install seqkit
+install=true
+
 # tumor DNA (original sample)
 tA1="/samples/P23993/P23993_6.1.fastq.gz"
 tA2="/samples/P23993/P23993_6.2.fastq.gz"

--- a/config.txt
+++ b/config.txt
@@ -1,6 +1,11 @@
 # install seqkit
 install=true
 
+# manifest text
+bed="/samples/P23993/S31285117_grch38.bed"
+client="NOI"
+cancer="Lung Cancer"
+
 # tumor DNA (original sample)
 tA1="/samples/P23993/P23993_6.1.fastq.gz"
 tA2="/samples/P23993/P23993_6.2.fastq.gz"

--- a/simulate_contamination.sh
+++ b/simulate_contamination.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # Simulate cross-sample contamination by creating fastq with x% reads from sample A and y% from sample by
 # Strategy: 
@@ -10,7 +10,7 @@
 # Reads from B: 4M
 
 # Get input
-usage() { echo "Usage: $0 [-p <percentage contamination to simulate>] [-r <total M reads in output fastq>]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 [-p <percentage contamination to simulate>] [-r <total M reads in output fastq>] [config file]" 1>&2; exit 1; }
 
 while getopts ":p:r:" o; do
     case "${o}" in
@@ -154,14 +154,18 @@ create_manifest() {
 
 run() {
 
-    echo "# - conda install seqkit .."
-    conda install -c bioconda seqkit
-
     set_params
     print_params
 
     # Read config file
     . $config 
+    
+    # Install seqkit via conda, if config says so
+    if [[ $install == true ]]
+    then
+        echo "# - conda install seqkit .."
+        conda install -c bioconda seqkit
+    fi
 
     # Tumor DNA
     echo "==============================="

--- a/simulate_contamination.sh
+++ b/simulate_contamination.sh
@@ -154,6 +154,8 @@ create_manifest() {
 
 run() {
 
+    set -eux pipefail
+    
     set_params
     print_params
 

--- a/simulate_contamination.sh
+++ b/simulate_contamination.sh
@@ -137,9 +137,9 @@ create_manifest() {
     mani="$outdir/manifest.yaml"
     echo "manifestVersion: v1alpha" > $mani
     echo "name: cont${perc}_${totreads}" >> $mani
-    echo "bed: /samples/P23993/S31285117_grch38.bed" >> $mani
-    echo "client: NOI" >> $mani
-    echo "cancer: Lung Cancer" >> $mani
+    echo "bed: $bed" >> $mani
+    echo "client: $client" >> $mani
+    echo "cancer: $cancer" >> $mani
     echo "normalReads:" >> $mani
     echo "  - C.normal.${perc}_percent_contamination.R1.fq.gz " >> $mani
     echo "  - C.normal.${perc}_percent_contamination.R2.fq.gz " >> $mani


### PR DESCRIPTION
* usage() now mentions where the config file needs to be
* Manifest cancer, client, and bedfile are no longer hardcoded; they're now part of the config 
* Add `set -eux pipefail` so if seqkit or conda has an error, the script will stop
* The shebang for simulate_contamination.sh is now consistent with the shebang on create_files.sh
* Installation via conda is now optional, based on a config option
   * Rationale: Not everyone uses conda. For those that do, there's no need to run `conda install` every time the script is run. 